### PR TITLE
Add add_sql.sh into main

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@ LOCAL_DB_USER='postgres'
 LOCAL_DB_PASSWORD='postgres'
 
 ##### Heroku database ######
-DB_HOST='ec2-34-241-19-183.eu-west-1.compute.amazonaws.com'
-DB_NAME='d6bf5d21qkbk2g'
-DB_USER='nocxlzaxjcrovp'
-DB_PASSWORD='134e54c862abd2320637613b62e2b48d25c6e809d7bb6ba2f894aa457bdccd49'
+DB_HOST='ec2-34-225-103-117.compute-1.amazonaws.com'
+DB_NAME='daev2l01mpuko4'
+DB_USER='jmulkzmzzwaath'
+DB_PASSWORD='fdcd4611512ddc046daaefbff2396ee23074d280e013e1de5692afa4d1eda3e1'

--- a/.env
+++ b/.env
@@ -14,7 +14,8 @@ LOCAL_DB_USER='postgres'
 LOCAL_DB_PASSWORD='postgres'
 
 ##### Heroku database ######
-DB_HOST='ec2-34-225-103-117.compute-1.amazonaws.com'
-DB_NAME='daev2l01mpuko4'
-DB_USER='jmulkzmzzwaath'
-DB_PASSWORD='fdcd4611512ddc046daaefbff2396ee23074d280e013e1de5692afa4d1eda3e1'
+DB_HOST=ec2-34-225-103-117.compute-1.amazonaws.com
+DB_NAME=daev2l01mpuko4
+DB_USER=jmulkzmzzwaath
+DB_PORT=5432
+DB_PASSWORD=fdcd4611512ddc046daaefbff2396ee23074d280e013e1de5692afa4d1eda3e1

--- a/add_sql.sh
+++ b/add_sql.sh
@@ -1,0 +1,18 @@
+# Insert your URI below
+URI="postgres://jmulkzmzzwaath:fdcd4611512ddc046daaefbff2396ee23074d280e013e1de5692afa4d1eda3e1@ec2-34-225-103-117.compute-1.amazonaws.com:5432/daev2l01mpuko4"
+
+# Create the /sql folder for scripts.
+mkdir sql
+
+# Download all necessary sql scripts into /sql.
+curl https://raw.githubusercontent.com/remmyzen/AppStoreRawDemo/main/sql/AppStoreSchema.sql --output sql/AppStoreSchema.sql
+curl https://raw.githubusercontent.com/remmyzen/AppStoreRawDemo/main/sql/AppStoreCustomers.sql --output sql/AppStoreCustomers.sql
+curl https://raw.githubusercontent.com/remmyzen/AppStoreRawDemo/main/sql/AppStoreGames.sql --output sql/AppStoreGames.sql
+curl https://raw.githubusercontent.com/remmyzen/AppStoreRawDemo/main/sql/AppStoreDownloads.sql --output sql/AppStoreDownloads.sql
+
+# Run the scripts to insert data.
+psql ${URI} -f sql/AppStoreSchema.sql
+psql ${URI} -f sql/AppStoreCustomers.sql
+psql ${URI} -f sql/AppStoreGames.sql
+psql ${URI} -f sql/AppStoreDownloads.sql
+

--- a/add_sql.sh
+++ b/add_sql.sh
@@ -1,14 +1,31 @@
-# Insert your URI below
-URI="postgres://jmulkzmzzwaath:fdcd4611512ddc046daaefbff2396ee23074d280e013e1de5692afa4d1eda3e1@ec2-34-225-103-117.compute-1.amazonaws.com:5432/daev2l01mpuko4"
+# Construct the URI from the .env
+DB_HOST=''
+DB_NAME=''
+DB_USER=''
+DB_PORT=''
+DB_PASSWORD=''
 
-# Create the /sql folder for scripts.
-mkdir sql
+while IFS= read -r line
+do
+  if [[ $line == DB_HOST* ]]
+  then
+    DB_HOST=$(cut -d "=" -f2- <<< $line)
+  elif [[ $line == DB_NAME* ]]
+  then
+    DB_NAME=$(cut -d "=" -f2- <<< $line)
+  elif [[ $line == DB_USER* ]]
+  then
+    DB_USER=$(cut -d "=" -f2- <<< $line)
+  elif [[ $line == DB_PORT* ]]
+  then
+    DB_PORT=$(cut -d "=" -f2- <<< $line)
+  elif [[ $line == DB_PASSWORD* ]]
+  then
+    DB_PASSWORD=$(cut -d "=" -f2- <<< $line)
+  fi
+done < ".env"
 
-# Download all necessary sql scripts into /sql.
-curl https://raw.githubusercontent.com/remmyzen/AppStoreRawDemo/main/sql/AppStoreSchema.sql --output sql/AppStoreSchema.sql
-curl https://raw.githubusercontent.com/remmyzen/AppStoreRawDemo/main/sql/AppStoreCustomers.sql --output sql/AppStoreCustomers.sql
-curl https://raw.githubusercontent.com/remmyzen/AppStoreRawDemo/main/sql/AppStoreGames.sql --output sql/AppStoreGames.sql
-curl https://raw.githubusercontent.com/remmyzen/AppStoreRawDemo/main/sql/AppStoreDownloads.sql --output sql/AppStoreDownloads.sql
+URI="postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
 
 # Run the scripts to insert data.
 psql ${URI} -f sql/AppStoreSchema.sql

--- a/add_sql.sh
+++ b/add_sql.sh
@@ -28,6 +28,7 @@ done < ".env"
 URI="postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME"
 
 # Run the scripts to insert data.
+psql ${URI} -f sql/AppStoreClean.sql
 psql ${URI} -f sql/AppStoreSchema.sql
 psql ${URI} -f sql/AppStoreCustomers.sql
 psql ${URI} -f sql/AppStoreGames.sql


### PR DESCRIPTION
Similar to the way that Homebrew's installation process works, I created add_sql.sh to `curl` and `psql` the AppStore sql files for the students. The step to curl and execute this bash file is described in the Overleaf document.